### PR TITLE
User Roles Complete - Do not merge until comments are read

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bootstrap-sass'
 gem 'devise'
+gem "pundit"
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -217,6 +219,7 @@ DEPENDENCIES
   jquery-rails
   pg
   pry
+  pundit
   rails (= 4.2.5)
   rails_12factor
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
+  include Pundit
   protect_from_forgery with: :exception
 end

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,5 +1,6 @@
 class WikisController < ApplicationController
   before_action :authenticate_user!, except: [:show]
+  
   def index
     @wikis = Wiki.all
     authorize @wikis
@@ -30,7 +31,7 @@ class WikisController < ApplicationController
 
   def edit
     @wiki = Wiki.find(params[:id])
-    authroize @wiki
+    authorize @wiki
   end
 
   def update

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,8 +1,8 @@
 class WikisController < ApplicationController
   before_action :authenticate_user!, except: [:show]
-  
+
   def index
-    @wikis = Wiki.all
+    @wikis = policy_scope(Wiki)
     authorize @wikis
   end
 
@@ -36,6 +36,7 @@ class WikisController < ApplicationController
 
   def update
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
 
     if @wiki.update_attributes(wiki_params)
       flash[:notice] = "Wiki was updated."

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,15 +1,18 @@
 class WikisController < ApplicationController
   before_action :authenticate_user!, except: [:show]
+  def index
+    @wikis = Wiki.all
+    authorize @wikis
+  end
 
   def new
     @wiki = Wiki.new
+    authorize @wiki
   end
 
   def create
-    @wiki = Wiki.new
-    @wiki.user = current_user
-    @wiki.title = params[:wiki][:title]
-    @wiki.body = params[:wiki][:body]
+    @wiki = current_user.wikis.create(wiki_params)
+    authorize @wiki
 
     if @wiki.save
       flash[:notice] = "Wiki was saved."
@@ -22,18 +25,18 @@ class WikisController < ApplicationController
 
   def show
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
   end
 
   def edit
     @wiki = Wiki.find(params[:id])
+    authroize @wiki
   end
 
   def update
     @wiki = Wiki.find(params[:id])
-    @wiki.title = params[:wiki][:title]
-    @wiki.body = params[:wiki][:body]
 
-    if @wiki.save
+    if @wiki.update_attributes(wiki_params)
       flash[:notice] = "Wiki was updated."
       redirect_to @wiki
     else
@@ -44,6 +47,7 @@ class WikisController < ApplicationController
 
   def destroy
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
 
     if @wiki.destroy
       flash[:notice] = "\"#{@wiki.title}\" was deleted successfully."
@@ -52,5 +56,11 @@ class WikisController < ApplicationController
       flash.now[:alert] = "Error deleting Wiki. Try again."
       render :show
     end
+  end
+
+  private
+
+  def wiki_params
+    params.require(:wiki).permit(:title, :body, :role)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,22 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  after_initialize :assign_role
+
+  def standard?
+    role == 'standard'
+  end
+
+  def admin?
+    role == 'admin'
+  end
+
+  def premium?
+    role == 'premium'
+  end
+
+  def assign_role
+    self.role ||= 'standard'
+  end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,3 +1,7 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
+
+  # def published?
+    
+  #
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,7 +1,6 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
 
-  # def published?
-    
+  # def published?  
   #
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user.present?
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -19,7 +19,7 @@ class ApplicationPolicy
   end
 
   def new?
-    create?
+    user.present?
   end
 
   def update?

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -7,7 +7,7 @@ class WikiPolicy < ApplicationPolicy
   end
 
   def new?
-    user.present?
+    create?
   end
 
   def create?
@@ -19,7 +19,7 @@ class WikiPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.present?
+    update?
   end
 
   def show?
@@ -32,5 +32,16 @@ class WikiPolicy < ApplicationPolicy
 
   def destroy?
     user.admin?
+  end
+
+  class Scope < Scope
+    def resolve
+      # if user.present?
+      #   scope.all
+      # else
+      #   scope.where(private: false)
+      # end
+      scope.all
+    end
   end
 end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -1,0 +1,17 @@
+class WikiPolicy < ApplicationPolicy
+  attr_reader :user, :wiki
+
+  def initialize(user, wiki)
+    @user = user
+    @wiki = wiki
+  end
+
+  def new
+    user.present?
+  end
+
+  # def destroy?
+    # user.admin?
+    # user.created_at < 1.month.ago
+  # end
+end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -6,12 +6,31 @@ class WikiPolicy < ApplicationPolicy
     @wiki = wiki
   end
 
-  def new
+  def new?
     user.present?
   end
 
-  # def destroy?
-    # user.admin?
-    # user.created_at < 1.month.ago
-  # end
+  def create?
+    user.present?
+  end
+
+  def index?
+    user.present?
+  end
+
+  def edit?
+    user.present?
+  end
+
+  def show?
+    user.present?
+  end
+
+  def update?
+    user.present?
+  end
+
+  def destroy?
+    user.admin?
+  end
 end

--- a/db/migrate/20160318165515_add_role_to_user.rb
+++ b/db/migrate/20160318165515_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309005910) do
+ActiveRecord::Schema.define(version: 20160318165515) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20160309005910) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "role"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
@bjblock - Everything is working. When users are created, (both through the browser and through the console) they are assigned a default role of "standard". Users who do not own a specific Wiki can edit the Wiki but this is where my question is; is my code too simple? I've accomplished the task of allowing other users to edit Wiki's that weren't created by them, but I almost feel it wasn't done specifically enough if that makes sense. Should I be implementing more defined code that does this or is what I've done okay for what we're trying to accomplish here for the checkpoint? Thanks!
